### PR TITLE
Use angular-coords for polar->cartesian coordinates

### DIFF
--- a/src/clj/genartlib/geometry.clj
+++ b/src/clj/genartlib/geometry.clj
@@ -1,9 +1,9 @@
 (ns genartlib.geometry
   (:require
-    [genartlib.algebra :refer [angle avg interpolate]]
-    [quil.core :refer [dist cos sin]])
+   [genartlib.algebra :refer [angle avg interpolate angular-coords]]
+   [quil.core :refer [dist]])
   (:import
-    [genartlib PolyUtils]))
+   [genartlib PolyUtils]))
 
 (defn rotate-polygon
   "Rotates a polygon clockwise about its centroid.  The theta argument determines
@@ -24,11 +24,9 @@
       (map (fn [[x y]]
              (let [current-angle (angle x-centroid y-centroid x y)
                    new-angle (+ current-angle theta)
-                   hypot (dist x y x-centroid y-centroid)
-                   x-offset (* hypot (cos new-angle))
-                   y-offset (* hypot (sin new-angle))]
-               [(+ x-offset x-centroid) (+ y-offset y-centroid)]))
-             points))))
+                   hypot (dist x y x-centroid y-centroid)]
+               (angular-coords x-centroid y-centroid new-angle hypot)))
+           points))))
 
 (defn polygon-contains-point?
   "Returns true if a polygon contains the given point.  The polygon

--- a/src/clj/genartlib/random.clj
+++ b/src/clj/genartlib/random.clj
@@ -1,6 +1,7 @@
 (ns genartlib.random
   (:require [genartlib.util :refer [between?]]
-            [quil.core :refer [random-gaussian cos sin abs random sqrt TWO-PI]])
+            [quil.core :refer [random-gaussian cos sin abs random sqrt TWO-PI]]
+            [genartlib.algebra :as a])
   (:import [org.apache.commons.math3.distribution ParetoDistribution]))
 
 (defn gauss
@@ -50,15 +51,12 @@
    shape."
   [scale shape]
   (.sample (ParetoDistribution. scale shape)))
-
 (defn random-point-in-circle
   "Picks a random point in a circle with a given center and radius"
   [x y radius]
   (let [theta (random 0 TWO-PI)
-        r (simple-triangular radius)
-        x-offset (* r (cos theta))
-        y-offset (* r (sin theta))]
-    [(+ x x-offset) (+ y y-offset)]))
+        r (simple-triangular radius)]
+    (a/angular-coords x y theta r)))
 
 (defn odds
   "Returns true with probability 'chance', where change is between 0 and 1.0"

--- a/src/clj/genartlib/random.clj
+++ b/src/clj/genartlib/random.clj
@@ -1,7 +1,7 @@
 (ns genartlib.random
   (:require [genartlib.util :refer [between?]]
-            [quil.core :refer [random-gaussian cos sin abs random sqrt TWO-PI]]
-            [genartlib.algebra :as a])
+            [quil.core :refer [random-gaussian abs random sqrt TWO-PI]]
+            [genartlib.algebra :refer [angular-coords]])
   (:import [org.apache.commons.math3.distribution ParetoDistribution]))
 
 (defn gauss
@@ -56,7 +56,7 @@
   [x y radius]
   (let [theta (random 0 TWO-PI)
         r (simple-triangular radius)]
-    (a/angular-coords x y theta r)))
+    (angular-coords x y theta r)))
 
 (defn odds
   "Returns true with probability 'chance', where change is between 0 and 1.0"


### PR DESCRIPTION
In 2 places, coordinates are converted from polar to cartesian. It occured to me that this is just the same as `algebra/angular-coords`. For consistency and robustness, i'd propose to use that single function everywhere.