### PR TITLE
Interpolate exp tanh

### DIFF
--- a/src/clj/genartlib/algebra.clj
+++ b/src/clj/genartlib/algebra.clj
@@ -11,11 +11,14 @@
 (declare rescale)
 
 (defn interpolate
-  "Interpolates a point between [start, finish] at point t, where
-   t is between 0.0 and 1.0. "
+  "Interpolates a point between [start, finish] at point t, where t is between
+  0.0 and 1.0. When exponent or tanh-factor options are supplied, an exponential
+  or s-curve interpolation is used, instead of linear interpolation. Exponent
+  should always be positive."
   ([start finish t]
    (+ (* (- 1.0 t) start) (* t finish)))
   ([{:keys [exponent tanh-factor]} start finish t]
+   (when exponent (assert (pos? exponent))) ;; Exponent should always be > 0
    (cond
      exponent (let [lo (pow 1 exponent)
                     hi (pow 2 exponent)]

--- a/src/clj/genartlib/algebra.clj
+++ b/src/clj/genartlib/algebra.clj
@@ -8,7 +8,13 @@
   [& values]
   (/ (apply + values) (count values)))
 
-(declare rescale)
+(defn rescale
+  "Rescales value from range [old-min, old-max] to [new-min, new-max]"
+  [value old-min old-max new-min new-max]
+  (let [old-spread (- old-max old-min)
+        new-spread (- new-max new-min)]
+    (+ (* (- value old-min) (/ new-spread old-spread))
+       new-min)))
 
 (defn interpolate
   "Interpolates a point between [start, finish] at point t, where t is between
@@ -33,18 +39,10 @@
    t is between 0.0 and 1.0"
   [start-point finish-point t]
   (map
-    (fn [a b]
-      (interpolate a b t))
-    start-point
-    finish-point))
-
-(defn rescale
-  "Rescales value from range [old-min, old-max] to [new-min, new-max]"
-  [value old-min old-max new-min new-max]
-  (let [old-spread (- old-max old-min)
-        new-spread (- new-max new-min)]
-    (+ (* (- value old-min) (/ new-spread old-spread))
-       new-min)))
+   (fn [a b]
+     (interpolate a b t))
+   start-point
+   finish-point))
 
 (defn line-intersection
   "Finds the intersection of two lines.  Each line argument is a vector

--- a/src/clj/genartlib/algebra.clj
+++ b/src/clj/genartlib/algebra.clj
@@ -23,15 +23,16 @@
   should always be positive."
   ([start finish t]
    (+ (* (- 1.0 t) start) (* t finish)))
-  ([{:keys [exponent tanh-factor]} start finish t]
+  ([{:keys [exponent tanh-factor s-factor]} start finish t]
    (when exponent (assert (pos? exponent))) ;; Exponent should always be > 0
    (cond
      exponent (let [lo (pow 1 exponent)
                     hi (pow 2 exponent)]
                 (-> t inc (pow exponent) (rescale lo hi start finish)))
      tanh-factor (cond-> (Math/tanh (* t tanh-factor))
-                   (neg? tanh-factor) inc
-                   :always (rescale 0 1 start finish))
+                   (neg? tanh-factor) (rescale -1 0 finish start)
+                   (pos? tanh-factor) (rescale 0 1 start finish))
+     s-factor (-> t (rescale 0 1 -1 1) (* s-factor) Math/tanh (rescale -1 1 start finish))
      :else (interpolate start finish t))))
 
 (defn interpolate-multi

--- a/src/clj/genartlib/algebra.clj
+++ b/src/clj/genartlib/algebra.clj
@@ -35,14 +35,21 @@
      :else (interpolate start finish t))))
 
 (defn interpolate-multi
-  "Interpolates between two multi-dimensional points at t, where
-   t is between 0.0 and 1.0"
-  [start-point finish-point t]
-  (map
-   (fn [a b]
-     (interpolate a b t))
-   start-point
-   finish-point))
+  "Interpolates between two multi-dimensional points at t, where t is between
+  0.0 and 1.0. Also accepts curve props like interpolate."
+  ([start-point finish-point t]
+   (map
+    (fn [a b]
+      (interpolate a b t))
+    start-point
+    finish-point))
+  ([props start-point finish-point t]
+   (let [interpolate-fn (partial interpolate props)]
+     (map
+      (fn [a b]
+        (interpolate-fn a b t))
+      start-point
+      finish-point))))
 
 (defn line-intersection
   "Finds the intersection of two lines.  Each line argument is a vector

--- a/src/clj/genartlib/algebra.clj
+++ b/src/clj/genartlib/algebra.clj
@@ -1,18 +1,29 @@
 (ns genartlib.algebra
   (:require
-    [genartlib.util :refer [between?]]
-    [quil.core :refer [PI atan2 cos sin dist sqrt abs]]))
+   [genartlib.util :refer [between?]]
+   [quil.core :refer [PI atan2 cos sin dist sqrt abs pow]]))
 
 (defn avg
   "Returns the average of the arguments"
   [& values]
   (/ (apply + values) (count values)))
 
+(declare rescale)
+
 (defn interpolate
   "Interpolates a point between [start, finish] at point t, where
-   t is between 0.0 and 1.0"
-  [start finish t]
-  (+ (* (- 1.0 t) start) (* t finish)))
+   t is between 0.0 and 1.0. "
+  ([start finish t]
+   (+ (* (- 1.0 t) start) (* t finish)))
+  ([{:keys [exponent tanh-factor]} start finish t]
+   (cond
+     exponent (let [lo (pow 1 exponent)
+                    hi (pow 2 exponent)]
+                (-> t inc (pow exponent) (rescale lo hi start finish)))
+     tanh-factor (cond-> (Math/tanh (* t tanh-factor))
+                   (neg? tanh-factor) inc
+                   :always (rescale 0 1 start finish))
+     :else (interpolate start finish t))))
 
 (defn interpolate-multi
   "Interpolates between two multi-dimensional points at t, where

--- a/test/genartlib/algebra_test.clj
+++ b/test/genartlib/algebra_test.clj
@@ -19,7 +19,12 @@
 
   (is (= 10.0 (a/interpolate 10.0 0.0 0.0)))
   (is (= 5.0 (a/interpolate 10.0 0.0 0.5)))
-  (is (= 0.0 (a/interpolate 10.0 0.0 1.0))))
+  (is (= 0.0 (a/interpolate 10.0 0.0 1.0)))
+
+  (is (= 41.66666666666667 (a/interpolate {:exponent 2} 0 100 0.5)))
+  (is (= 54.25822558944361 (a/interpolate {:exponent 0.5} 0 100 0.5)))
+  (is (= 75.50813375962908 (a/interpolate {:tanh-factor -0.5} 0 100 0.5)))
+  (is (= 63.51489523872873 (a/interpolate {:tanh-factor 1.5} 0 100 0.5))))
 
 (deftest rescale-test
   (is (= 5.0 (a/rescale 0.5 0.0 1.0 0.0 10.0)))

--- a/test/genartlib/algebra_test.clj
+++ b/test/genartlib/algebra_test.clj
@@ -21,9 +21,9 @@
   (is (= 5.0 (a/interpolate 10.0 0.0 0.5)))
   (is (= 0.0 (a/interpolate 10.0 0.0 1.0)))
 
-  (is (= 41.66666666666667 (a/interpolate {:exponent 2} 0 100 0.5)))
+  (is (= 41.66666666666667 (a/interpolate {:exponent 2} 0 100 0.5))) ;; Interpolate along a exponential curve of exponent 2
   (is (= 54.25822558944361 (a/interpolate {:exponent 0.5} 0 100 0.5)))
-  (is (= 75.50813375962908 (a/interpolate {:tanh-factor -0.5} 0 100 0.5)))
+  (is (= 75.50813375962908 (a/interpolate {:tanh-factor -0.5} 0 100 0.5))) ;; Interpolate along a 'S' curve of factor -0.5
   (is (= 63.51489523872873 (a/interpolate {:tanh-factor 1.5} 0 100 0.5))))
 
 (deftest rescale-test

--- a/test/genartlib/algebra_test.clj
+++ b/test/genartlib/algebra_test.clj
@@ -21,10 +21,25 @@
   (is (= 5.0 (a/interpolate 10.0 0.0 0.5)))
   (is (= 0.0 (a/interpolate 10.0 0.0 1.0)))
 
-  (is (= 41.66666666666667 (a/interpolate {:exponent 2} 0 100 0.5))) ;; Interpolate along a exponential curve of exponent 2
-  (is (= 54.25822558944361 (a/interpolate {:exponent 0.5} 0 100 0.5)))
-  (is (= 75.50813375962908 (a/interpolate {:tanh-factor -0.5} 0 100 0.5))) ;; Interpolate along a 'S' curve of factor -0.5
-  (is (= 63.51489523872873 (a/interpolate {:tanh-factor 1.5} 0 100 0.5))))
+  (testing "with curve props,"
+    (testing "when exponent"
+      (testing "> 1 pushes towards 0"
+        (is (> 0.25 (a/interpolate {:exponent 2} 0.0 1.0 0.25)))
+        (is (> 0.75 (a/interpolate {:exponent 2} 0.0 1.0 0.75))))
+      (testing "< 1 pushes towards 1"
+        (is (< 0.25 (a/interpolate {:exponent 0.5} 0.0 1.0 0.25)))
+        (is (< 0.75 (a/interpolate {:exponent 0.5} 0.0 1.0 0.75)))))
+    (testing "when tanh factor"
+      (testing "> 0 pushes towards 1"
+        (is (< 0.25 (a/interpolate {:tanh-factor 2} 0.0 1.0 0.25)))
+        (is (< 0.75 (a/interpolate {:tanh-factor 2} 0.0 1.0 0.75))))
+      (testing "< 0 pushes towards 0"
+        (is (< 0.25 (a/interpolate {:tanh-factor -2} 0.0 1.0 0.25)))
+        (is (< 0.75 (a/interpolate {:tanh-factor -2} 0.0 1.0 0.75)))))
+    (testing "when s factor"
+      (testing "> 1 pushes towards boundaries"
+        (is (> 0.25 (a/interpolate {:s-factor 2} 0.0 1.0 0.25)))
+        (is (< 0.75 (a/interpolate {:s-factor 2} 0.0 1.0 0.75)))))))
 
 (deftest rescale-test
   (is (= 5.0 (a/rescale 0.5 0.0 1.0 0.0 10.0)))


### PR DESCRIPTION
Ok so i'm just making cool stuff for my own art projects. And I'd like to share this with you!

I've extended `algebra/interpolate` to accept some curve coefficients as optional arg.
Besides linear interpolation, there's also exponential, tanh and s-curve interpolation.

You can supply a curve to your interpolation like this:

```
(algebra/interpolate {:exponent 2} 0 1 0.5) ~= 0.4667
(algebra/interpolate {:tanh-factor -0.5} 0 1 0.5) ~= 0.755
```
I've added tests for clarity...